### PR TITLE
Adding switch to show all incidents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ PagerDuty TUI is a minimalist terminal user interface developed in Rust for mana
 
 Download the last release on [Gihtub Releases](https://github.com/Mk555/pagerduty-tui/releases/latest)
 
+## Shortcuts
+
+Here are the options in the app : 
+- `Q/<Esc>` : Quit
+- `<Up>/<Down>/<Home>` : Move in the list of incidents
+- `R` : Refresh the list of incidents
+- `<Space>` : Acknowledge incident
+- `A` : Acknowledge all the incidents in the service
+- `G` : Trigger the switch to show incidents assigned to everyone, not only the current user
+- `<Enter>` : Open the incident in the default browser
+
 ## Update
 
 To update, run the self update : 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -14,6 +14,7 @@ pub enum Action {
   Acknowledge,
   AcknowledgeAllService,
   HideAck,
+  AllIncidents,
   Quit,
   None,
 }
@@ -25,7 +26,7 @@ pub async fn update(app: &mut App, msg: Action) -> Action {
   match msg {
     Action::UpdateIncidents => {
       app.refreshing = true;
-      let _res = get_items_async(app.pager_duty.get_pagerduty_domain(),app.pager_duty.get_pagerduty_api_key(), app.items_tx.clone()).await;
+      let _res = get_items_async(app.pager_duty.get_pagerduty_domain(),app.pager_duty.get_pagerduty_api_key(), app.all_incidents, app.items_tx.clone()).await;
     },
     Action::Increment => {
       app.next();
@@ -68,6 +69,15 @@ pub async fn update(app: &mut App, msg: Action) -> Action {
         app.hide_ack = true;
       }
     },
+    Action::AllIncidents => {
+      if app.all_incidents {
+        app.all_incidents = false;
+      } else {
+        app.all_incidents = true;
+      }
+      let _res = get_items_async(app.pager_duty.get_pagerduty_domain(),app.pager_duty.get_pagerduty_api_key(), app.all_incidents, app.items_tx.clone()).await;
+      app.refreshing = true;
+    },
     Action::Quit => app.should_quit = true, // You can handle cleanup and exit here
     _ => {},
   };
@@ -91,6 +101,7 @@ pub fn handle_event(_app: &App, tx: mpsc::UnboundedSender<Action>) -> tokio::tas
               crossterm::event::KeyCode::Char(' ') => Action::Acknowledge,
               crossterm::event::KeyCode::Char('a') | crossterm::event::KeyCode::Char('A') => Action::AcknowledgeAllService,
               crossterm::event::KeyCode::Char('h') => Action::HideAck,
+              crossterm::event::KeyCode::Char('g') => Action::AllIncidents,
               crossterm::event::KeyCode::Char('q') | crossterm::event::KeyCode::Esc => Action::Quit,
 
               _ => Action::None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -62,6 +62,7 @@ pub struct App {
   pub items_rx: UnboundedReceiver<Vec<Incident>>,
   pub refreshing: bool,
   pub hide_ack: bool,
+  pub all_incidents: bool,
   pub should_quit: bool,
   pub refresh_rate: Option<i64>,
   pub ticker: i64,
@@ -70,7 +71,7 @@ pub struct App {
 impl App {
   pub async fn new(pd: PagerDuty, config: &AppConfig) -> Self {
 
-    let data_vec = pd.get_incidents().await.expect("Error getting incidents from PagerDuty");
+    let data_vec = pd.get_incidents(false).await.expect("Error getting incidents from PagerDuty");
     let (action_tx, action_rx) = mpsc::unbounded_channel();
     let (items_tx, items_rx) = mpsc::unbounded_channel();
 
@@ -85,6 +86,7 @@ impl App {
       should_quit: false,
       refreshing: false,
       hide_ack: false,
+      all_incidents: false,
       action_tx,
       action_rx,
       items_tx,
@@ -163,7 +165,7 @@ pub async fn run_app<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> io
 
       app.ticker = 0;
 
-      let _res = get_items_async(app.pager_duty.get_pagerduty_domain(),app.pager_duty.get_pagerduty_api_key(), app.items_tx.clone()).await;
+      let _res = get_items_async(app.pager_duty.get_pagerduty_domain(),app.pager_duty.get_pagerduty_api_key(), app.all_incidents, app.items_tx.clone()).await;
     } else {
       app.ticker += 1;
     }

--- a/src/pagerduty.rs
+++ b/src/pagerduty.rs
@@ -168,12 +168,7 @@ impl PagerDuty {
         assignee = String::from("----------");
       }
       let created_at_str: String;
-      if all_incidents {
-        created_at_str = String::from(format!("{}\n{}", incident.created_at, assignee));
-      }
-      else {
-        created_at_str = incident.created_at;
-      }
+      created_at_str = String::from(format!("{}\n{}", incident.created_at, assignee));
 
       incident.service.summary = format!("{}", incident.service.summary);
       // Prepare the text to show

--- a/src/pagerduty.rs
+++ b/src/pagerduty.rs
@@ -28,6 +28,14 @@ struct PagerDutyService{
   summary: String,
 }
 #[derive(Debug, Deserialize)]
+struct PagerDutyAssignee{
+  summary: String,
+}
+#[derive(Debug, Deserialize)]
+struct PagerDutyAssignment{
+  assignee: PagerDutyAssignee,
+}
+#[derive(Debug, Deserialize)]
 struct PagerDutyPriority {
 }
 
@@ -44,6 +52,7 @@ struct PagerDutyIncident {
   status: String,
   service: PagerDutyService,
   priority: Option<PagerDutyPriority>,
+  assignments: Vec<PagerDutyAssignment>,
 }
 
 pub struct Incident {
@@ -103,13 +112,19 @@ impl PagerDuty {
     &self.domain
   }
 
-  pub async fn get_incidents(&self) -> Result<Vec<Incident>, String> {
+  pub async fn get_incidents(&self, all_incidents: bool) -> Result<Vec<Incident>, String> {
     let statuses: [&str; 2] = ["triggered","acknowledged"];
     let mut pd_incidents: Vec<PagerDutyIncident> = Vec::new();
 
     for status in statuses {
-      let url_requets:String = format!("{}{}?statuses[]={}&user_ids[]={}&limit=100",
-        PAGERDUTY_URL,PAGERDUTY_INCIDENTS_ENDPOINT, status, &self.current_user_id);
+      let url_requets:String;
+      if all_incidents {
+        url_requets = format!("{}{}?statuses[]={}&limit=100",
+            PAGERDUTY_URL,PAGERDUTY_INCIDENTS_ENDPOINT, status);
+      } else {
+        url_requets = format!("{}{}?statuses[]={}&user_ids[]={}&limit=100",
+            PAGERDUTY_URL,PAGERDUTY_INCIDENTS_ENDPOINT, status, &self.current_user_id);
+      }
       let client = Client::new();
       let response = client.get(&url_requets)
           .header(CONTENT_TYPE, "application/json")
@@ -143,6 +158,22 @@ impl PagerDuty {
       if incident.status == "triggered" {
         triggered = true;
       }
+      
+      // Assignee
+      let assignee: String;
+      if incident.assignments.len() > 0 {
+        assignee = incident.assignments.get(0).unwrap().assignee.summary.clone();
+      }
+      else {
+        assignee = String::from("----------");
+      }
+      let created_at_str: String;
+      if all_incidents {
+        created_at_str = String::from(format!("{}\n{}", incident.created_at, assignee));
+      }
+      else {
+        created_at_str = incident.created_at;
+      }
 
       incident.service.summary = format!("{}", incident.service.summary);
       // Prepare the text to show
@@ -153,7 +184,7 @@ impl PagerDuty {
         summary: incident.summary,
         service: incident.service.summary,
         status: incident.status,
-        created_at: incident.created_at,
+        created_at: created_at_str,
         triggered: triggered,
       });
     }
@@ -216,13 +247,13 @@ pub async fn acknowledge_async(api_key: &str, id: &str) -> Result<(), ()> {
   Ok(())
 }
 
-pub async fn get_items_async(domain: &str, api_key: &str, tx: mpsc::UnboundedSender<Vec<Incident>>) -> Result<(), ()> {
+pub async fn get_items_async(domain: &str, api_key: &str, all_incidents: bool, tx: mpsc::UnboundedSender<Vec<Incident>>) -> Result<(), ()> {
   let pd_api_key = String::from(api_key);
   let pd_domain = String::from(domain);
 
   tokio::spawn(async move {
     let pd = PagerDuty::new(&pd_domain, &pd_api_key).await;
-    let items_res = pd.get_incidents().await;
+    let items_res = pd.get_incidents(all_incidents).await;
     match items_res {
       Ok(items) => {
         tx.send(items)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,7 +5,7 @@ use ratatui::{
 use crate::{app::App, pagerduty::Incident};
 
 const INFO_TEXT: &str =
-  "(Esc) Quit | (↑/↓/🏠) Navigate | (R) Refresh | (Space) Ack | (A) Ack all service | (H) Hide Ack | (Enter) Open in browser";
+  "(Esc) Quit | (↑/↓/🏠) Navigate | (R) Refresh | (Space) Ack | (A) Ack service | (G) Show all | (Enter) Open";
 
 const SPLASH_TEXT: &str = " ____   __    ___  ____  ____    ____  _  _  ____  _  _ \n(  _ \\ / _\\  / __)(  __)(  _ \\  (    \\/ )( \\(_  _)( \\/ )\n ) __//    \\( (_ \\ ) _)  )   /   ) D () \\/ (  )(   )  / \n(__)  \\_/\\_/ \\___/(____)(__\\_)  (____/\\____/ (__) (__/  ";
 


### PR DESCRIPTION
New feature requested to be able to see all the incidents, not only the ones assigned to the current user.
When this is activated you can see the name of the user to whom the incident is assigned below the creation date/time.